### PR TITLE
Fix a crash when there are no `tileproperties` inside tileset object

### DIFF
--- a/src/tileUtilities.js
+++ b/src/tileUtilities.js
@@ -604,7 +604,7 @@ class TileUtilities {
             //matches the current tile, and that sub-object has a `name` property,
             //then create a sprite and assign the tile properties onto
             //the sprite
-            if (tileproperties[key] && tileproperties[key].name) {
+            if (tileproperties && tileproperties[key] && tileproperties[key].name) {
 
               //Make a sprite
               tileSprite = new this.Sprite(texture);


### PR DESCRIPTION
Fixing this case:
<img width="813" alt="image" src="https://user-images.githubusercontent.com/2737310/45800811-4acdc500-bcb2-11e8-9901-76074103a650.png">
