### PR TITLE
Add guard when no tiles has properties

### DIFF
--- a/src/tileUtilities.js
+++ b/src/tileUtilities.js
@@ -604,7 +604,7 @@ class TileUtilities {
             //matches the current tile, and that sub-object has a `name` property,
             //then create a sprite and assign the tile properties onto
             //the sprite
-            if (tileproperties[key] && tileproperties[key].name) {
+            if (tileproperties && tileproperties[key] && tileproperties[key].name) {
 
               //Make a sprite
               tileSprite = new this.Sprite(texture);


### PR DESCRIPTION
If no tile has properties, there is no `tileproperties` field in the tileset and the map loading fails.